### PR TITLE
fix installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,17 @@ If you plan to run the app in a conda or virtual environment, make sure to set u
     pip install git+https://github.com/aolabsai/ao_arch git+https://github.com/aolabsai/ao_core
     ```
 
-3. Run the application with the following command:
+3. Create a .env file in the root directory and add your openai api key for embedding model:
 
     ```bash
-    streamlit run recommender.py
+    OPENAI_API_KEY=your_openai_api_key_here
+    ```
+*Note: make sure the key has the permissions to use the embedding models, it actually uses the `text-embedding-3-small` model and the `gpt-3.5-turbo` model*
+
+4. Run the application with the following command:
+
+    ```bash
+    streamlit run main.py --server.port 8501
     ```
 
 4. Once running, the app will be accessible at `localhost:8501`.


### PR DESCRIPTION
So to try it out locally the readme says to do stuff and at last do `streamlit run recommender.py` , there's no such file named `recommender.py` , the docker file does contain the [entry point](https://github.com/aolabsai/Recommender/blob/762095168c98f04f69c0ba1a920327dacf37f6cd/Dockerfile#L50) which is basically `streamlit run main.py --server.port=8501` .

So I tried that, but then I got an error saying `ModuleNotFoundError: No module named 'config'` , the comment [here](https://github.com/aolabsai/Recommender/blob/762095168c98f04f69c0ba1a920327dacf37f6cd/main.py#L17) says `#own modules ao_core arch and config` but the import statement is actually `from config import openai_api_key` , idk what config were you guys trying to call / refer here, but seems like its being used as a client for embedding models. 

Anyways fixed everything, now it should work fine :) 